### PR TITLE
Section headers instead of list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,10 @@ Third person survival game (tutorial) series for Unreal Engine 4.
 
 Consists of 6 sections, published every two weeks between March and June.
 
-- **Section 1:** This section sets up the third person character movement with animation, object interaction, simple hunger system, all with networking support.
-- **Section 2:** Adds weapon support for the character, a flashlight, UT-style inventory with on-character visual representation of the carried items and deals with damage, death and respawns for players.
+## Section 1
+This section sets up the third person character movement with animation, object interaction, simple hunger system, all with networking support.
+
+##Section 2
+Adds weapon support for the character, a flashlight, UT-style inventory with on-character visual representation of the carried items and deals with damage, death and respawns for players.
 
 For questions & feedback visit the official thread on the unreal engine forums: https://forums.unrealengine.com/showthread.php?63678-Upcoming-C-Gameplay-Example-Series-Making-a-Survival-Game


### PR DESCRIPTION
This changes README from list of sections to sub-headers for every section. Reference: #3 

Preview: https://github.com/toqueteos/EpicSurvivalGameSeries/tree/readme-headers-fix

I can make further changes if you like, like adding a separator just below the latest section or anything alike. Just don't merge until everything is fine :+1: