### PR TITLE
Check for null instigator when receiving damage

### DIFF
--- a/SurvivalGame/Source/SurvivalGame/Private/SCharacter.cpp
+++ b/SurvivalGame/Source/SurvivalGame/Private/SCharacter.cpp
@@ -535,8 +535,8 @@ float ASCharacter::TakeDamage(float Damage, struct FDamageEvent const& DamageEve
 		}
 		else
 		{
-			auto pawn = EventInstigator ? EventInstigator->GetPawn() : nullptr;
-			PlayHit(ActualDamage, DamageEvent, pawn, DamageCauser, false);
+			auto Pawn = EventInstigator ? EventInstigator->GetPawn() : nullptr;
+			PlayHit(ActualDamage, DamageEvent, Pawn, DamageCauser, false);
 		}
 	}
 

--- a/SurvivalGame/Source/SurvivalGame/Private/SCharacter.cpp
+++ b/SurvivalGame/Source/SurvivalGame/Private/SCharacter.cpp
@@ -535,7 +535,8 @@ float ASCharacter::TakeDamage(float Damage, struct FDamageEvent const& DamageEve
 		}
 		else
 		{
-			PlayHit(ActualDamage, DamageEvent, EventInstigator->GetPawn(), DamageCauser, false);
+			auto pawn = EventInstigator ? EventInstigator->GetPawn() : nullptr;
+			PlayHit(ActualDamage, DamageEvent, pawn, DamageCauser, false);
 		}
 	}
 


### PR DESCRIPTION
Currently the editor crashes when the player is damaged by a bomb.  This happens because `ASBombActor::OnExplode` passes a null pointer as event instigator to `UGameplayStatics::ApplyRadialDamage` (which seems correct to me, since the bomb actor has no controller).  But `ASCharacter::TakeDamage` then calls `GetPawn` on this null pointer which causes the crash.  This patch simply checks whether `EventInstigator` is null and passes a null pointer as `PawnInstigator` to `ASCharacter::PlayHit`.