### PR TITLE
UE4.13 - resolve 'UAnimInstance' undefined type 

### DIFF
--- a/SurvivalGame/Source/SurvivalGame/Private/Editor/SoundNodeLocalPlayer.cpp
+++ b/SurvivalGame/Source/SurvivalGame/Private/Editor/SoundNodeLocalPlayer.cpp
@@ -12,7 +12,6 @@ void USoundNodeLocalPlayer::ParseNodes(FAudioDevice* AudioDevice, const UPTRINT 
 	check(IsInGameThread());
 
 	AActor* SoundOwner = ActiveSound.GetAudioComponentID() ? UAudioComponent::GetAudioComponentFromID(ActiveSound.GetAudioComponentID())->GetOwner() : nullptr;
-	
 	APlayerController* PCOwner = Cast<APlayerController>(SoundOwner);
 	APawn* PawnOwner = (PCOwner ? PCOwner->GetPawn() : Cast<APawn>(SoundOwner));
 

--- a/SurvivalGame/Source/SurvivalGame/Private/Editor/SoundNodeLocalPlayer.cpp
+++ b/SurvivalGame/Source/SurvivalGame/Private/Editor/SoundNodeLocalPlayer.cpp
@@ -5,12 +5,13 @@
 #include "SoundNodeLocalPlayer.h"
 
 
+
 void USoundNodeLocalPlayer::ParseNodes(FAudioDevice* AudioDevice, const UPTRINT NodeWaveInstanceHash, FActiveSound& ActiveSound, const FSoundParseParameters& ParseParams, TArray<FWaveInstance*>& WaveInstances)
 {
 	// The accesses to the Pawn will be unsafe once we thread audio, deal with this at that point
 	check(IsInGameThread());
 
-	AActor* SoundOwner = ActiveSound.GetAudioComponent() ? ActiveSound.GetAudioComponent()->GetOwner() : nullptr;
+	AActor* SoundOwner = ActiveSound.GetAudioComponentID() ? UAudioComponent::GetAudioComponentFromID(ActiveSound.GetAudioComponentID())->GetOwner() : nullptr;
 	APlayerController* PCOwner = Cast<APlayerController>(SoundOwner);
 	APawn* PawnOwner = (PCOwner ? PCOwner->GetPawn() : Cast<APawn>(SoundOwner));
 

--- a/SurvivalGame/Source/SurvivalGame/Private/Editor/SoundNodeLocalPlayer.cpp
+++ b/SurvivalGame/Source/SurvivalGame/Private/Editor/SoundNodeLocalPlayer.cpp
@@ -12,6 +12,7 @@ void USoundNodeLocalPlayer::ParseNodes(FAudioDevice* AudioDevice, const UPTRINT 
 	check(IsInGameThread());
 
 	AActor* SoundOwner = ActiveSound.GetAudioComponentID() ? UAudioComponent::GetAudioComponentFromID(ActiveSound.GetAudioComponentID())->GetOwner() : nullptr;
+	
 	APlayerController* PCOwner = Cast<APlayerController>(SoundOwner);
 	APawn* PawnOwner = (PCOwner ? PCOwner->GetPawn() : Cast<APawn>(SoundOwner));
 

--- a/SurvivalGame/Source/SurvivalGame/Private/Player/SCharacter.cpp
+++ b/SurvivalGame/Source/SurvivalGame/Private/Player/SCharacter.cpp
@@ -8,6 +8,7 @@
 #include "SCharacterMovementComponent.h"
 #include "SCarryObjectComponent.h"
 #include "SBaseCharacter.h"
+#include "Runtime/Engine/Classes/Animation/AnimInstance.h"
 
 
 // Sets default values

--- a/SurvivalGame/Source/SurvivalGame/Private/Player/SCharacter.cpp
+++ b/SurvivalGame/Source/SurvivalGame/Private/Player/SCharacter.cpp
@@ -11,7 +11,7 @@
 #include "Runtime/Engine/Classes/Animation/AnimInstance.h"
 
 
-// Sets default values
+// Sets the default values
 ASCharacter::ASCharacter(const class FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
 {

--- a/SurvivalGame/Source/SurvivalGame/Private/Player/SCharacter.cpp
+++ b/SurvivalGame/Source/SurvivalGame/Private/Player/SCharacter.cpp
@@ -11,7 +11,7 @@
 #include "Runtime/Engine/Classes/Animation/AnimInstance.h"
 
 
-// Sets the default values
+// Sets default values
 ASCharacter::ASCharacter(const class FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
 {


### PR DESCRIPTION
upgrading to UE4.13 causes an undefined type error for 'UAnimInstance', so an additional include is needed.