### PR TITLE
UE4.13

### DIFF
--- a/SurvivalGame/Source/SurvivalGame/Private/Editor/SoundNodeLocalPlayer.cpp
+++ b/SurvivalGame/Source/SurvivalGame/Private/Editor/SoundNodeLocalPlayer.cpp
@@ -10,7 +10,7 @@ void USoundNodeLocalPlayer::ParseNodes(FAudioDevice* AudioDevice, const UPTRINT 
 	// The accesses to the Pawn will be unsafe once we thread audio, deal with this at that point
 	check(IsInGameThread());
 
-	AActor* SoundOwner = ActiveSound.GetAudioComponent() ? ActiveSound.GetAudioComponent()->GetOwner() : nullptr;
+	AActor* SoundOwner = ActiveSound.GetAudioComponentID() ? UAudioComponent::GetAudioComponentFromID(ActiveSound.GetAudioComponentID())->GetOwner() : nullptr;
 	APlayerController* PCOwner = Cast<APlayerController>(SoundOwner);
 	APawn* PawnOwner = (PCOwner ? PCOwner->GetPawn() : Cast<APawn>(SoundOwner));
 

--- a/SurvivalGame/Source/SurvivalGame/Private/Player/SCharacter.cpp
+++ b/SurvivalGame/Source/SurvivalGame/Private/Player/SCharacter.cpp
@@ -8,7 +8,7 @@
 #include "SCharacterMovementComponent.h"
 #include "SCarryObjectComponent.h"
 #include "SBaseCharacter.h"
-
+#include "Runtime/Engine/Classes/Animation/AnimInstance.h"
 
 // Sets default values
 ASCharacter::ASCharacter(const class FObjectInitializer& ObjectInitializer)


### PR DESCRIPTION
This pull request resolves the minor compilation issues associated with upgrading to UE4.13

Essentially, the project needs an extra include statement in SCharacater.cpp and a change inside SoundNodeLocalPlayer.cpp to alter the way the UAudioComponent is retrieved from the ActiveSound; it no longer has a get method as it stores and id and name instead of a reference.

On a separate note, I had a bit of a fail creating a pull request initially and accidentally created two separate ones for each change. I have since closed both those pull requests and lumped both commits into a single request.