### PR TITLE
Add UPROPERTY to PreviousWeapon pointer

### DIFF
--- a/SurvivalGame/Source/SurvivalGame/Public/Player/SCharacter.h
+++ b/SurvivalGame/Source/SurvivalGame/Public/Player/SCharacter.h
@@ -296,6 +296,7 @@ public:
 	UPROPERTY(Transient, ReplicatedUsing = OnRep_CurrentWeapon)
 	class ASWeapon* CurrentWeapon;
 
+	UPROPERTY()
 	class ASWeapon* PreviousWeapon;
 
 	/* Update the weapon mesh to the newly equipped weapon, this is triggered during an anim montage.


### PR DESCRIPTION
In UE4 C++ Garbage Collection system it's important to mark raw pointers as UPROPERTY to be considered for garbage collection.